### PR TITLE
feat: Add 'asChild' prop to Button component for enhanced flexibility…

### DIFF
--- a/components/(portfolio)/Navbar.tsx
+++ b/components/(portfolio)/Navbar.tsx
@@ -267,7 +267,7 @@ export function Navbar() {
                 rotate: { duration: 0.6, ease: "linear" }
               }}
             >
-              <Button variant="premium" size="sm" glow>
+              <Button variant="premium" size="sm" glow asChild>
                 <a
                   href="/resume.pdf"
                   target="_blank"
@@ -512,7 +512,7 @@ export function Navbar() {
                       damping: 25
                     }}
                   >
-                    <Button variant="premium" size="sm" className="w-full">
+                    <Button variant="premium" size="sm" className="w-full" asChild>
                       <a
                         href="/resume.pdf"
                         target="_blank"

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -6,6 +6,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size?: 'sm' | 'md' | 'lg';
   children: React.ReactNode;
   glow?: boolean;
+  asChild?: boolean;
 }
 
 export function Button({ 
@@ -14,6 +15,7 @@ export function Button({
   className, 
   children, 
   glow = false,
+  asChild = false,
   ...props 
 }: ButtonProps) {
   const baseClasses = 'inline-flex items-center justify-center rounded-xl font-semibold transition-all duration-300 ease-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[var(--background)] disabled:opacity-50 disabled:cursor-not-allowed relative overflow-hidden group';
@@ -32,15 +34,26 @@ export function Button({
     lg: 'px-8 py-3.5 text-lg'
   };
   
+  const combinedClasses = cn(
+    baseClasses, 
+    variants[variant], 
+    sizes[size], 
+    glow && 'shadow-[var(--shadow-glow)]',
+    className
+  );
+
+  if (asChild) {
+    // When asChild is true, we clone the child element and apply our classes
+    const child = React.Children.only(children) as React.ReactElement;
+    return React.cloneElement(child, {
+      className: cn(combinedClasses, child.props.className),
+      ...props
+    });
+  }
+  
   return (
     <button
-      className={cn(
-        baseClasses, 
-        variants[variant], 
-        sizes[size], 
-        glow && 'shadow-[var(--shadow-glow)]',
-        className
-      )}
+      className={combinedClasses}
       {...props}
     >
       {children}


### PR DESCRIPTION
This pull request introduces an enhancement to the `Button` component by adding an `asChild` prop, allowing the button's styles and props to be applied directly to a child element (such as an anchor tag). This improves flexibility, particularly for cases where a button should render as a different HTML element (e.g., a link), while maintaining consistent styling. The `Navbar` component is updated to utilize this new prop for resume download links.

**Button Component Enhancement:**

* Added an `asChild` prop to the `Button` component, enabling it to clone its child element and apply button styles and props directly to that child when `asChild` is true. This allows for more flexible rendering, such as rendering a styled anchor tag instead of a button. [[1]](diffhunk://#diff-c54ad3f590e0a7da1b1c328a6b058d38b6b8eb6176201128d6341665ba262b18R9) [[2]](diffhunk://#diff-c54ad3f590e0a7da1b1c328a6b058d38b6b8eb6176201128d6341665ba262b18R18) [[3]](diffhunk://#diff-c54ad3f590e0a7da1b1c328a6b058d38b6b8eb6176201128d6341665ba262b18L35-R56)

**Navbar Component Updates:**

* Updated the resume download buttons in the `Navbar` to use the `asChild` prop, wrapping anchor tags with the `Button` component to ensure consistent styling and correct HTML semantics for links. [[1]](diffhunk://#diff-7d420a7d77ce39fbaf72911f8a4964bf9eb4a394a638212c193968c017eedc31L270-R270) [[2]](diffhunk://#diff-7d420a7d77ce39fbaf72911f8a4964bf9eb4a394a638212c193968c017eedc31L515-R515)… in rendering